### PR TITLE
Log in to github docker repo

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -19,7 +19,7 @@ jobs:
           tools-deps: latest
 
       - name: Log in to docker
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --password-stdin
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u <token> --password-stdin
 
       - name: Generate dummy auth keys
         run: clojure -Akeygen

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -19,7 +19,7 @@ jobs:
           tools-deps: latest
 
       - name: Log in to docker
-        run: docker login docker.pkg.github.com --password ${{ secrets.GITHUB_TOKEN }}
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --password-stdin
 
       - name: Generate dummy auth keys
         run: clojure -Akeygen

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -19,7 +19,7 @@ jobs:
           tools-deps: latest
 
       - name: Log in to docker
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u <token> --password-stdin
+        run: docker login docker.pkg.github.com -u ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate dummy auth keys
         run: clojure -Akeygen

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           tools-deps: latest
 
+      - name: test pulling ci image
+        run: docker pull docker.pkg.github.com/briaoeuidhtns/wfs-backend/wfs-postgres-ci:1.0
+
       - name: Generate dummy auth keys
         run: clojure -Akeygen
 

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -19,7 +19,7 @@ jobs:
           tools-deps: latest
 
       - name: Log in to docker
-        run: docker login docker.pkg.github.com -u ${{ secrets.GITHUB_TOKEN }}
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u  --password-stdin ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate dummy auth keys
         run: clojure -Akeygen

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -19,7 +19,7 @@ jobs:
           tools-deps: latest
 
       - name: Log in to docker
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u  --password-stdin ${{ secrets.GITHUB_TOKEN }}
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{ secrets.GITHUB_TOKEN }} --password-stdin
 
       - name: Generate dummy auth keys
         run: clojure -Akeygen

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           tools-deps: latest
 
-      - name: test pulling ci image
-        run: docker pull docker.pkg.github.com/briaoeuidhtns/wfs-backend/wfs-postgres-ci:1.0
+      - name: Log in to docker
+        run: docker login docker.pkg.github.com --password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate dummy auth keys
         run: clojure -Akeygen


### PR DESCRIPTION
According to 
https://github.community/t/download-from-github-package-registry-without-authentication/14407
even public repos require authentication for some reason